### PR TITLE
refactor(mcsmapi): 重构 API 类方法并优化模型定义

### DIFF
--- a/mcsmapi/__init__.py
+++ b/mcsmapi/__init__.py
@@ -36,7 +36,7 @@ class MCSMAPI:
         return self
 
     def overview(self) -> OverviewModel:
-        return Overview().init()
+        return Overview.init()
 
     def instance(self) -> Instance:
         return Instance()

--- a/mcsmapi/apis/daemon.py
+++ b/mcsmapi/apis/daemon.py
@@ -2,11 +2,11 @@ from typing import Any
 from mcsmapi.pool import ApiPool
 from mcsmapi.request import send
 from mcsmapi.models.daemon import DaemonConfig, DaemonModel
-from mcsmapi.models.daemon.instance import InstanceDetail
 
 
 class Daemon:
-    def show(self) -> list[DaemonConfig]:
+    @staticmethod
+    def show() -> list[DaemonConfig]:
         """
         获取全部节点配置信息
 
@@ -18,11 +18,12 @@ class Daemon:
             f"{ApiPool.SERVICE}/remote_services_list",
         )
         return [DaemonConfig(**daemon) for daemon in daemons]
-        
-    def system(self) -> list[DaemonModel]:
+
+    @staticmethod
+    def system() -> list[DaemonModel]:
         """
         获取全部节点的系统信息
-        
+
         返回:
         - List[DaemonModel]: 节点系统信息列表
         """
@@ -32,7 +33,8 @@ class Daemon:
         )
         return [DaemonModel(**daemon) for daemon in daemons]
 
-    def add(self, config: dict[str, Any]) -> str:
+    @staticmethod
+    def add(config: dict[str, Any]) -> str:
         """
         新增一个节点。
 
@@ -47,8 +49,8 @@ class Daemon:
             f"{ApiPool.SERVICE}/remote_service",
             data=DaemonConfig(**config).dict(),
         )
-
-    def delete(self, daemonId: str) -> bool:
+    @staticmethod
+    def delete(daemonId: str) -> bool:
         """
         删除一个节点。
 
@@ -61,8 +63,8 @@ class Daemon:
         return send(
             "DELETE", f"{ApiPool.SERVICE}/remote_service", params={"uuid": daemonId}
         )
-
-    def link(self, daemonId: str) -> bool:
+    @staticmethod
+    def link(daemonId: str) -> bool:
         """
         连接一个节点。
 
@@ -75,11 +77,11 @@ class Daemon:
         return send(
             "GET", f"{ApiPool.SERVICE}/link_remote_service", params={"uuid": daemonId}
         )
-
-    def update(self, daemonId: str, config: dict[str, Any]) -> bool:
+    @staticmethod
+    def update(daemonId: str, config: dict[str, Any]) -> bool:
         """
         更新一个节点的配置。
-        
+
         **不建议直接使用此函数，建议调用overview()后在remote属性内使用updateConfig方法按需更新**
 
         参数:

--- a/mcsmapi/apis/file.py
+++ b/mcsmapi/apis/file.py
@@ -6,14 +6,14 @@ import os
 
 
 class File:
+    @staticmethod
     def show(
-        self,
         daemonId: str,
         uuid: str,
         target: str = "",
         page: int = 0,
         page_size: int = 100,
-        file_name: str = ""
+        file_name: str = "",
     ) -> FileList:
         """
         获取文件列表
@@ -43,7 +43,8 @@ class File:
         )
         return FileList(**result, daemonId=daemonId, uuid=uuid)
 
-    def content(self, daemonId: str, uuid: str, target: str) -> str | bytes:
+    @staticmethod
+    def content(daemonId: str, uuid: str, target: str) -> str | bytes:
         """
         获取文件内容
 
@@ -62,7 +63,8 @@ class File:
             data={"target": target},
         )
 
-    def update(self, daemonId: str, uuid: str, target: str, text: str) -> bool:
+    @staticmethod
+    def update(daemonId: str, uuid: str, target: str, text: str) -> bool:
         """
         更新文件内容
 
@@ -82,7 +84,8 @@ class File:
             data={"target": target, "text": text},
         )
 
-    def download(self, daemonId: str, uuid: str, file_name: str) -> str:
+    @staticmethod
+    def download(daemonId: str, uuid: str, file_name: str) -> str:
         """
         下载文件
 
@@ -105,9 +108,8 @@ class File:
         base_url = urllib.parse.urljoin(f"{protocol}://{result.addr}", "download")
         return urllib.parse.urljoin(base_url, f"{result.password}/{file_name}")
 
-    async def upload(
-        self, daemonId: str, uuid: str, file: bytes, upload_dir: str
-    ) -> bool:
+    @staticmethod
+    async def upload(daemonId: str, uuid: str, file: bytes, upload_dir: str) -> bool:
         """
         上传文件
 
@@ -132,7 +134,8 @@ class File:
         await upload(final_url, file)
         return True
 
-    def copy(self, daemonId: str, uuid: str, copy_map: dict[str, str]) -> bool:
+    @staticmethod
+    def copy(daemonId: str, uuid: str, copy_map: dict[str, str]) -> bool:
         """
         复制多个文件夹或文件到指定位置。
 
@@ -152,7 +155,8 @@ class File:
             data={"targets": targets},
         )
 
-    def copyOne(self, daemonId: str, uuid: str, source: str, target: str) -> bool:
+    @staticmethod
+    def copyOne(daemonId: str, uuid: str, source: str, target: str) -> bool:
         """
         复制单个文件或文件夹到指定位置。
 
@@ -165,9 +169,10 @@ class File:
         **返回:**
         - bool: 移动成功后返回True。
         """
-        return self.copy(daemonId, uuid, {source: target})
+        return File.copy(daemonId, uuid, {source: target})
 
-    def move(self, daemonId: str, uuid: str, copy_map: dict[str, str]) -> bool:
+    @staticmethod
+    def move(daemonId: str, uuid: str, copy_map: dict[str, str]) -> bool:
         """
         移动多个文件或文件夹到指定位置。
 
@@ -187,7 +192,8 @@ class File:
             data={"targets": targets},
         )
 
-    def moveOne(self, daemonId: str, uuid: str, source: str, target: str) -> bool:
+    @staticmethod
+    def moveOne(daemonId: str, uuid: str, source: str, target: str) -> bool:
         """
         从源路径移动单个文件或文件夹到目标路径。
 
@@ -200,9 +206,10 @@ class File:
         返回:
         - bool: 移动成功后返回True。
         """
-        return self.move(daemonId, uuid, {source: target})
+        return File.move(daemonId, uuid, {source: target})
 
-    def rename(self, daemonId: str, uuid: str, source: str, new_name: str) -> bool:
+    @staticmethod
+    def rename(daemonId: str, uuid: str, source: str, new_name: str) -> bool:
         """
         重命名单个文件或文件夹。
 
@@ -217,9 +224,10 @@ class File:
         """
         directory = os.path.dirname(source)
         target = os.path.join(directory, new_name)
-        return self.moveOne(daemonId, uuid, source, target)
+        return File.moveOne(daemonId, uuid, source, target)
 
-    def zip(self, daemonId: str, uuid: str, source: str, targets: list[str]) -> bool:
+    @staticmethod
+    def zip(daemonId: str, uuid: str, source: str, targets: list[str]) -> bool:
         """
         压缩多个文件或文件夹到指定位置。
 
@@ -239,8 +247,9 @@ class File:
             data={"type": 1, "code": "utf-8", "source": source, "targets": targets},
         )
 
+    @staticmethod
     def unzip(
-        self, daemonId: str, uuid: str, source: str, target: str, code: str = "utf-8"
+        daemonId: str, uuid: str, source: str, target: str, code: str = "utf-8"
     ) -> bool:
         """
         解压缩指定的zip文件到目标位置。
@@ -263,7 +272,8 @@ class File:
             data={"type": 2, "code": code, "source": source, "targets": target},
         )
 
-    def delete(self, daemonId: str, uuid: str, targets: list[str]) -> bool:
+    @staticmethod
+    def delete(daemonId: str, uuid: str, targets: list[str]) -> bool:
         """
         删除多个文件或文件夹。
 
@@ -282,7 +292,8 @@ class File:
             data={"targets": targets},
         )
 
-    def createFile(self, daemonId: str, uuid: str, target: str) -> bool:
+    @staticmethod
+    def createFile(daemonId: str, uuid: str, target: str) -> bool:
         """
         创建文件。
 
@@ -301,7 +312,8 @@ class File:
             data={"target": target},
         )
 
-    def createFloder(self, daemonId: str, uuid: str, target: str) -> bool:
+    @staticmethod
+    def createFloder(daemonId: str, uuid: str, target: str) -> bool:
         """
         创建文件夹
 

--- a/mcsmapi/apis/image.py
+++ b/mcsmapi/apis/image.py
@@ -4,7 +4,8 @@ from mcsmapi.models.image import DockerImageItem, DockerContainerItem, DockerNet
 
 
 class Image:
-    def images(self, daemonId: str) -> list[DockerImageItem]:
+    @staticmethod
+    def images(daemonId: str) -> list[DockerImageItem]:
         """
         获取镜像列表
 
@@ -24,7 +25,8 @@ class Image:
 
         return [DockerImageItem(**item) for item in result]
 
-    def containers(self, daemonId: str) -> list[DockerContainerItem]:
+    @staticmethod
+    def containers(daemonId: str) -> list[DockerContainerItem]:
         """
         获取容器列表
 
@@ -44,7 +46,8 @@ class Image:
 
         return [DockerContainerItem(**item) for item in result]
 
-    def network(self, daemonId: str) -> list[DockerNetworkItem]:
+    @staticmethod
+    def network(daemonId: str) -> list[DockerNetworkItem]:
         """
         获取网络接口列表
 
@@ -63,7 +66,8 @@ class Image:
         )
         return [DockerNetworkItem(**item) for item in result]
 
-    def add(self, daemonId: str, dockerFile: str, name: str, tag: str) -> bool:
+    @staticmethod
+    def add(daemonId: str, dockerFile: str, name: str, tag: str) -> bool:
         """
         新增一个镜像
 
@@ -83,7 +87,8 @@ class Image:
             data={"dockerFile": dockerFile, "name": name, "tag": tag},
         )
 
-    def progress(self, daemonId: str) -> dict[str, int]:
+    @staticmethod
+    def progress(daemonId: str) -> dict[str, int]:
         """
         获取镜像构建进度
 

--- a/mcsmapi/apis/instance.py
+++ b/mcsmapi/apis/instance.py
@@ -10,8 +10,8 @@ from mcsmapi.models.instance import (
 
 
 class Instance:
+    @staticmethod
     def search(
-        self,
         daemonId: str,
         page: int = 1,
         page_size: int = 20,
@@ -49,7 +49,8 @@ class Instance:
         )
         return InstanceSearchList(**result, daemonId=daemonId)
 
-    def detail(self, daemonId: str, uuid: str) -> InstanceDetail:
+    @staticmethod
+    def detail(daemonId: str, uuid: str) -> InstanceDetail:
         """
         获取指定实例的详细信息
 
@@ -67,7 +68,8 @@ class Instance:
         )
         return InstanceDetail(**result)
 
-    def create(self, daemonId: str, config: dict[str, Any]) -> InstanceCreateResult:
+    @staticmethod
+    def create(daemonId: str, config: dict[str, Any]) -> InstanceCreateResult:
         """
         创建一个实例。
 
@@ -86,10 +88,11 @@ class Instance:
         )
         return InstanceCreateResult(**result)
 
-    def updateConfig(self, daemonId: str, uuid: str, config: dict) -> str | bool:
+    @staticmethod
+    def updateConfig(daemonId: str, uuid: str, config: dict) -> str | bool:
         """
         更新实例配置。
-        
+
         **不建议直接使用此函数，建议调用search后在data属性内使用updateConfig方法按需更新**
 
         **参数:**
@@ -108,9 +111,8 @@ class Instance:
         )
         return result.get("uuid", True)
 
-    def delete(
-        self, daemonId: str, uuids: list[str], deleteFile: bool = False
-    ) -> list[str]:
+    @staticmethod
+    def delete(daemonId: str, uuids: list[str], deleteFile: bool = False) -> list[str]:
         """
         删除实例。
 
@@ -129,7 +131,8 @@ class Instance:
             data={"uuids": uuids, "deleteFile": deleteFile},
         )
 
-    def start(self, daemonId: str, uuid: str) -> str | bool:
+    @staticmethod
+    def start(daemonId: str, uuid: str) -> str | bool:
         """
         启动实例。
 
@@ -147,7 +150,8 @@ class Instance:
         )
         return result.get("instanceUuid", True)
 
-    def stop(self, daemonId: str, uuid: str) -> str | bool:
+    @staticmethod
+    def stop(daemonId: str, uuid: str) -> str | bool:
         """
         关闭实例。
 
@@ -165,7 +169,8 @@ class Instance:
         )
         return result.get("instanceUuid", True)
 
-    def restart(self, daemonId: str, uuid: str) -> str | bool:
+    @staticmethod
+    def restart(daemonId: str, uuid: str) -> str | bool:
         """
         重启实例。
 
@@ -183,7 +188,8 @@ class Instance:
         )
         return result.get("instanceUuid", True)
 
-    def kill(self, daemonId: str, uuid: str) -> str | bool:
+    @staticmethod
+    def kill(daemonId: str, uuid: str) -> str | bool:
         """
         强制关闭实例。
 
@@ -201,7 +207,8 @@ class Instance:
         )
         return result.get("instanceUuid", True)
 
-    def batchOperation(self, instances: list[dict[str, str]], operation: str) -> bool:
+    @staticmethod
+    def batchOperation(instances: list[dict[str, str]], operation: str) -> bool:
         """
         对多个实例进行批量操作。
 
@@ -217,7 +224,8 @@ class Instance:
         else:
             raise ValueError("operation must be one of start, stop, restart, kill")
 
-    def update(self, daemonId: str, uuid: str) -> bool:
+    @staticmethod
+    def update(daemonId: str, uuid: str) -> bool:
         """
         升级实例。
 
@@ -234,7 +242,8 @@ class Instance:
             params={"daemonId": daemonId, "uuid": uuid, "task_name": "update"},
         )
 
-    def command(self, daemonId: str, uuid: str, command: str) -> str:
+    @staticmethod
+    def command(daemonId: str, uuid: str, command: str) -> str:
         """
         向实例发送命令。
 
@@ -253,7 +262,8 @@ class Instance:
         )
         return result.get("instanceUuid", True)
 
-    def get_output(self, daemonId: str, uuid: str, size: int | str = "") -> str:
+    @staticmethod
+    def get_output(daemonId: str, uuid: str, size: int | str = "") -> str:
         """
         获取实例输出。
 
@@ -271,8 +281,8 @@ class Instance:
             params={"daemonId": daemonId, "uuid": uuid, "size": size},
         )
 
+    @staticmethod
     def reinstall(
-        self,
         daemonId: str,
         uuid: str,
         targetUrl: str,

--- a/mcsmapi/apis/overview.py
+++ b/mcsmapi/apis/overview.py
@@ -4,7 +4,8 @@ from mcsmapi.models.overview import OverviewModel
 
 
 class Overview:
-    def init(self):
+    @staticmethod
+    def init():
         """
         初始化方法，用于获取API概览信息并构建概览模型。
 

--- a/mcsmapi/apis/user.py
+++ b/mcsmapi/apis/user.py
@@ -5,8 +5,9 @@ from mcsmapi.models.user import SearchUserModel, UserConfig
 
 
 class User:
+    @staticmethod
     def search(
-        self, username: str = "", page: int = 1, page_size: int = 20, role: str = ""
+        username: str = "", page: int = 1, page_size: int = 20, role: str = ""
     ) -> SearchUserModel:
         """根据用户名和角色搜索用户信息
 
@@ -32,7 +33,8 @@ class User:
         )
         return SearchUserModel(**result)
 
-    def create(self, username: str, password: str, permission: int = 1) -> str | bool:
+    @staticmethod
+    def create(username: str, password: str, permission: int = 1) -> str | bool:
         """
         创建新用户的方法
 
@@ -50,7 +52,8 @@ class User:
             data={"username": username, "password": password, "permission": permission},
         ).get("uuid", True)
 
-    def update(self, uuid: str, config: dict[str, Any]) -> bool:
+    @staticmethod
+    def update(uuid: str, config: dict[str, Any]) -> bool:
         """
         更新用户信息的方法
 
@@ -66,10 +69,11 @@ class User:
         return send(
             "PUT",
             ApiPool.AUTH,
-            data={"uuid": uuid, "config": UserConfig(**config).dict()},
+            data={"uuid": uuid, "config": UserConfig(**config).model_dump()},
         )
 
-    def delete(self, uuids: list[str]) -> bool:
+    @staticmethod
+    def delete(uuids: list[str]) -> bool:
         """
         删除用户的方法
 

--- a/mcsmapi/models/common.py
+++ b/mcsmapi/models/common.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+
+
+class CpuMemChart(BaseModel):
+    """节点资源使用率信息"""
+
+    cpu: float = 0
+    """cpu使用率"""
+    mem: float = 0
+    """内存使用率"""
+
+
+class ProcessInfo(BaseModel):
+    """节点进程详细信息"""
+
+    cpu: int = 0
+    """远程节点使用的cpu资源(单位: byte)"""
+    memory: int = 0
+    """远程节点使用的内存资源(单位: byte)"""
+    cwd: str = ""
+    """远程节点的工作路径"""
+
+
+class InstanceInfo(BaseModel):
+    """实例统计信息"""
+
+    running: int = 0
+    """运行中实例数量"""
+    total: int = 0
+    """全部实例数量"""

--- a/mcsmapi/models/file.py
+++ b/mcsmapi/models/file.py
@@ -1,29 +1,34 @@
+from enum import IntEnum
 from pydantic import BaseModel
-from typing import List
 import os
+
+
+class FileType(IntEnum):
+    FOLDER = 0
+    FILE = 1
 
 
 class FileItem(BaseModel):
     """文件信息"""
 
-    """文件名称"""
     name: str = ""
+    """文件名称"""
+    size: int = 0
     """文件大小(单位: byte)"""
-    size: int = 0  # byte
-    """文件修改时间"""
     time: str = ""
+    """文件修改时间"""
+    mode: int = 777
     """文件操作权限(仅适用于Linux)"""
-    mode: int = 777  # Linux file permission
-    """文件类型，`0`为文件夹，`1`为文件"""
-    type: int = 0  # 0 = Folder, 1 = File
-    """远程节点uuid"""
+    type: FileType = FileType.FOLDER
+    """文件类型"""
     daemonId: str = ""
-    """实例的uiid"""
+    """远程节点uuid"""
     uuid: str = ""
-    """文件所在路径"""
+    """实例的uiid"""
     target: str = ""
-    """当前文件列表过滤条件"""
+    """文件所在路径"""
     file_name: str = ""
+    """当前文件列表过滤条件"""
 
     def rename(self, newName: str) -> bool:
         """
@@ -37,7 +42,7 @@ class FileItem(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().rename(
+        return File.rename(
             self.daemonId, self.uuid, os.path.join(self.target, self.name), newName
         )
 
@@ -50,14 +55,14 @@ class FileItem(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().delete(
+        return File.delete(
             self.daemonId, self.uuid, [os.path.join(self.target, self.name)]
         )
 
     def copy(self, target: str) -> bool:
         from mcsmapi.apis.file import File
 
-        return File().copyOne(
+        return File.copyOne(
             self.daemonId, self.uuid, os.path.join(self.target, self.name), target
         )
 
@@ -73,7 +78,7 @@ class FileItem(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().moveOne(
+        return File.moveOne(
             self.daemonId, self.uuid, os.path.join(self.target, self.name), target
         )
 
@@ -85,7 +90,7 @@ class FileItem(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().content(
+        return File.content(
             self.daemonId, self.uuid, os.path.join(self.target, self.name)
         )
 
@@ -101,7 +106,7 @@ class FileItem(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().zip(
+        return File.zip(
             self.daemonId, self.uuid, os.path.join(self.target, self.name), targets
         )
 
@@ -119,7 +124,7 @@ class FileItem(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().unzip(
+        return File.unzip(
             self.daemonId, self.uuid, os.path.join(self.target, self.name), target, code
         )
 
@@ -133,7 +138,7 @@ class FileItem(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().update(
+        return File.update(
             self.daemonId, self.uuid, os.path.join(self.target, self.name), text
         )
 
@@ -145,7 +150,7 @@ class FileItem(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().download(
+        return File.download(
             self.daemonId, self.uuid, os.path.join(self.target, self.name)
         )
 
@@ -153,22 +158,22 @@ class FileItem(BaseModel):
 class FileList(BaseModel):
     """文件列表"""
 
+    items: list[FileItem]
     """文件信息列表"""
-    items: List[FileItem]
-    """当前页数"""
     page: int = 0
-    """文件列表单页大小"""
+    """当前页数"""
     pageSize: int = 100
-    """总页数"""
+    """文件列表单页大小"""
     total: int = 0
-    """当前路径在远程节点的绝对路径"""
+    """总页数"""
     absolutePath: str = "\\"
-    """远程节点uuid"""
+    """当前路径在远程节点的绝对路径"""
     daemonId: str = ""
-    """实例uuid"""
+    """远程节点uuid"""
     uuid: str = ""
-    """文件（名称或目录）路径"""
+    """实例uuid"""
     target: str = ""
+    """文件（名称或目录）路径"""
 
     def __init__(self, **data: str):
         super().__init__(**data)
@@ -190,7 +195,7 @@ class FileList(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return await File().upload(self.daemonId, self.uuid, file, upload_dir)
+        return await File.upload(self.daemonId, self.uuid, file, upload_dir)
 
     def createFile(self, target: str) -> bool:
         """
@@ -204,7 +209,7 @@ class FileList(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().createFile(self.daemonId, self.uuid, target)
+        return File.createFile(self.daemonId, self.uuid, target)
 
     def createFloder(self, target: str) -> bool:
         """
@@ -218,11 +223,12 @@ class FileList(BaseModel):
         """
         from mcsmapi.apis.file import File
 
-        return File().createFloder(self.daemonId, self.uuid, target)
+        return File.createFloder(self.daemonId, self.uuid, target)
 
 
 class CommonConfig(BaseModel):
-    """文件下载密码"""
+
     password: str = ""
-    """文件下载地址"""
+    """文件下载密码"""
     addr: str = ""
+    """文件下载地址"""

--- a/mcsmapi/models/image.py
+++ b/mcsmapi/models/image.py
@@ -1,207 +1,209 @@
-from typing import List, Optional, Union
+from typing import Literal
 from pydantic import BaseModel
 
 
 class DockerConfig(BaseModel):
     """容器配置"""
 
-    """容器名称"""
     containerName: str = ""
-    """镜像名称"""
+    """容器名称"""
     image: str = ""
+    """镜像名称"""
+    memory: int = 0
     """容器分配内存(单位: MB)"""
-    memory: int = 0  # in MB
-    """容器端口映射"""
-    ports: List[str] = []  # ["25565:25565/tcp"]
+    ports: list[str] = []
+    """容器端口映射, eg:["25565:25565/tcp"]"""
+    extraVolumes: list[str] = []
     """额外挂载卷路径"""
-    extraVolumes: List[str] = []
+    maxSpace: int | None = None
     """容器可使用的最大磁盘空间(单位: MB)"""
-    maxSpace: Optional[int] = None
+    network: str | int | None = None
     """网络配置，可以是网络名称或ID"""
-    network: Optional[Union[str, int]] = None
+    io: str | int | None = None
     """容器的 IO 限制"""
-    io: Optional[Union[str, int]] = None
-    """网络模式(例如: bridge, host)"""
     networkMode: str = "bridge"
+    """网络模式(例如: bridge, host)"""
+    networkAliases: list[str] = []
     """网络别名列表"""
-    networkAliases: List[str] = []
-    """绑定的 CPU 核心"""
-    cpusetCpus: str = ""  # 例如 `0,1`
-    """CPU 使用率(单位: %)"""
+    cpusetCpus: str = ""
+    """绑定的 CPU 核心, eg: `0,1`"""
     cpuUsage: int = 100
-    """工作目录"""
+    """CPU 使用率(单位: %)"""
     workingDir: str = ""
+    """工作目录"""
+    env: list[str] = []
     """环境变量设置"""
-    env: List[str] = []
 
 
 class DockerImageItem(BaseModel):
     """Docker 镜像信息"""
 
-    """镜像唯一 ID"""
     Id: str = ""
-    """父镜像 ID"""
+    """镜像唯一 ID"""
     ParentId: str = ""
-    """镜像仓库标签"""
-    RepoTags: List[str] = []  # 例如 ["ubuntu:latest"]
+    """父镜像 ID"""
+    RepoTags: list[str] = []
+    """镜像仓库标签, eg: ["ubuntu:latest"]"""
+    RepoDigests: list[str] = []
     """镜像摘要"""
-    RepoDigests: List[str] = []
-    """镜像创建时间(Unix 时间戳)"""
     Created: int = 0
-    """镜像大小(单位: 字节)"""
+    """镜像创建时间(Unix 时间戳)"""
     Size: int = 0
-    """镜像的虚拟大小"""
+    """镜像大小(单位: 字节)"""
     VirtualSize: int = 0
-    """共享存储空间大小"""
+    """镜像的虚拟大小"""
     SharedSize: int = 0
-    """镜像标签"""
+    """共享存储空间大小"""
     Labels: dict[str, str] = {}
-    """依赖该镜像运行的容器数量"""
+    """镜像标签"""
     Containers: int = 0
+    """依赖该镜像运行的容器数量"""
 
 
 class DockerContainerItemPort(BaseModel):
     """Docker 容器端口映射"""
 
-    """容器内部端口"""
     PrivatePort: int = 0
+    """容器内部端口"""
+    PublicPort: int | None = None
     """映射到宿主机的端口"""
-    PublicPort: Optional[int] = None
-    """端口类型(tcp/udp)"""
-    Type: str = ""
+    Type: Literal["tcp", "udp"] = "tcp"
+    """端口类型"""
 
 
 class DockerContainerItemNetworkSettingsNetwork(BaseModel):
     """Docker 容器网络设置信息"""
 
-    """网络 ID"""
     NetworkID: str = ""
-    """网络端点 ID"""
+    """网络 ID"""
     EndpointID: str = ""
-    """网关地址"""
+    """网络端点 ID"""
     Gateway: str = ""
-    """分配的 IP 地址"""
+    """网关地址"""
     IPAddress: str = ""
-    """IP 地址前缀长度"""
+    """分配的 IP 地址"""
     IPPrefixLen: int = 0
-    """IPv6 网关地址"""
+    """IP 地址前缀长度"""
     IPv6Gateway: str = ""
-    """IPv6 地址"""
+    """IPv6 网关地址"""
     GlobalIPv6Address: str = ""
-    """IPv6 地址前缀长度"""
+    """IPv6 地址"""
     GlobalIPv6PrefixLen: int = 0
-    """MAC 地址"""
+    """IPv6 地址前缀长度"""
     MacAddress: str = ""
+    """MAC 地址"""
 
 
 class DockerContainerItemNetworkSettings(BaseModel):
     """Docker 容器的网络配置信息"""
 
-    """容器连接的所有网络"""
     Networks: dict[str, DockerContainerItemNetworkSettingsNetwork] = {}
+    """容器连接的所有网络"""
 
 
 class DockerContainerItemMount(BaseModel):
     """容器挂载点信息"""
 
-    """挂载名称"""
     Name: str = ""
-    """源路径"""
+    """挂载名称"""
     Source: str = ""
-    """目标路径"""
+    """源路径"""
     Destination: str = ""
-    """驱动类型"""
+    """目标路径"""
     Driver: str = ""
-    """挂载模式"""
+    """驱动类型"""
     Mode: str = ""
-    """是否允许读写"""
+    """挂载模式"""
     RW: bool = False
-    """传播模式"""
+    """是否允许读写"""
     Propagation: str = ""
+    """传播模式"""
 
 
 class DockerContainerItemHostConfig(BaseModel):
     """Docker 宿主机配置"""
 
-    """网络模式"""
     NetworkMode: str = ""
+    """网络模式"""
 
 
 class DockerContainerItem(BaseModel):
     """Docker 容器详细信息"""
 
-    """容器 ID"""
     Id: str = ""
+    """容器 ID"""
+    Names: list[str] = []
     """容器名称列表"""
-    Names: List[str] = []
-    """运行的镜像名称"""
     Image: str = ""
-    """镜像 ID"""
+    """运行的镜像名称"""
     ImageID: str = ""
-    """容器启动命令"""
+    """镜像 ID"""
     Command: str = ""
-    """容器创建时间(Unix 时间戳)"""
+    """容器启动命令"""
     Created: int = 0
-    """容器状态"""
+    """容器创建时间(Unix 时间戳)"""
     State: str = ""
-    """容器运行状态描述"""
+    """容器状态"""
     Status: str = ""
+    """容器运行状态描述"""
+    Ports: list[DockerContainerItemPort] = []
     """端口映射信息"""
-    Ports: List[DockerContainerItemPort] = []
-    """容器标签信息"""
     Labels: dict[str, str] = {}
-    """读写层大小(单位: 字节)"""
+    """容器标签信息"""
     SizeRw: int = 0
-    """根文件系统大小(单位: 字节)"""
+    """读写层大小(单位: 字节)"""
     SizeRootFs: int = 0
-    """宿主机配置"""
+    """根文件系统大小(单位: 字节)"""
     HostConfig: DockerContainerItemHostConfig = DockerContainerItemHostConfig()
+    """宿主机配置"""
+    NetworkSettings: DockerContainerItemNetworkSettings = (
+        DockerContainerItemNetworkSettings()
+    )
     """容器网络配置"""
-    NetworkSettings: DockerContainerItemNetworkSettings = DockerContainerItemNetworkSettings()
+    Mounts: list[DockerContainerItemMount] = []
     """容器挂载信息"""
-    Mounts: List[DockerContainerItemMount] = []
 
 
 class DockerNetworkItemIPAMConfig(BaseModel):
     """Docker 网络 IPAM 配置信息"""
 
-    """子网地址"""
     Subnet: str = ""
+    """子网地址"""
 
 
 class DockerNetworkItemIPAM(BaseModel):
     """Docker 网络的 IP 地址管理"""
 
-    """驱动类型"""
     Driver: str = ""
+    """驱动类型"""
+    Config: list[DockerNetworkItemIPAMConfig] = []
     """IPAM 配置"""
-    Config: List[DockerNetworkItemIPAMConfig] = []
 
 
 class DockerNetworkItem(BaseModel):
     """Docker 网络详细信息"""
 
-    """网络名称"""
     Name: str = ""
-    """网络 ID"""
+    """网络名称"""
     Id: str = ""
-    """网络创建时间"""
+    """网络 ID"""
     Created: str = ""
-    """网络作用范围(local/global)"""
+    """网络创建时间"""
     Scope: str = ""
-    """网络驱动类型"""
+    """网络作用范围(local/global)"""
     Driver: str = ""
-    """是否启用 IPv6"""
+    """网络驱动类型"""
     EnableIPv6: bool = False
-    """是否为内部网络"""
+    """是否启用 IPv6"""
     Internal: bool = False
-    """是否可附加"""
+    """是否为内部网络"""
     Attachable: bool = False
-    """是否为入口网络"""
+    """是否可附加"""
     Ingress: bool = False
-    """IPAM 配置信息"""
+    """是否为入口网络"""
     IPAM: DockerNetworkItemIPAM = DockerNetworkItemIPAM()
-    """网络选项"""
+    """IPAM 配置信息"""
     Options: dict[str, str] = {}
+    """网络选项"""
+    Containers: dict[str, dict] = {}
     """连接到此网络的容器信息"""
-    Containers: Optional[dict[str, dict]] = {}

--- a/mcsmapi/models/instance.py
+++ b/mcsmapi/models/instance.py
@@ -1,148 +1,168 @@
-from typing import List, Dict, Optional
+from enum import IntEnum
 from pydantic import BaseModel
 from mcsmapi.models.file import FileList
 from mcsmapi.models.image import DockerConfig
 
 
+class CRLFType(IntEnum):
+    """换行符"""
+
+    LF = 0
+    CR = 1
+    CRLF = 2
+
+
+class Status(IntEnum):
+    """实例状态"""
+
+    BUSY = -1
+    STOP = 0
+    STOPPING = 1
+    STARTING = 2
+    RUNNING = 3
+
+
 class TerminalOption(BaseModel):
     """终端选项"""
 
-    """是否启用颜色输出"""
     haveColor: bool = False
-    """是否使用伪终端 (PTY)"""
+    """是否启用颜色输出"""
     pty: bool = True
+    """是否使用伪终端 (PTY)"""
 
 
 class EventTask(BaseModel):
     """事件任务"""
 
-    """是否自动启动"""
     autoStart: bool = False
-    """是否自动重启"""
+    """是否自动启动"""
     autoRestart: bool = True
-    """是否忽略该任务"""
+    """是否自动重启"""
     ignore: bool = False
+    """是否忽略该任务"""
 
 
 class PingConfig(BaseModel):
-    """服务器 Ping 配置"""
+    """服务器 Ping 配置(新版已弃用)"""
 
-    """服务器 IP 地址"""
     ip: str = ""
-    """服务器端口"""
+    """服务器 IP 地址"""
     port: int = 25565
-    """Ping 类型 (1: 默认类型)"""
+    """服务器端口"""
     type: int = 1
+    """Ping 类型 (1: 默认类型)"""
 
 
 class InstanceConfig(BaseModel):
     """实例配置信息"""
 
-    """实例名称"""
     nickname: str = "New Name"
-    """启动命令"""
+    """实例名称"""
     startCommand: str = "cmd.exe"
-    """停止命令"""
+    """启动命令"""
     stopCommand: str = "^C"
-    """工作目录"""
+    """停止命令"""
     cwd: str = ""
+    """工作目录"""
+    ie: str = "utf8"
     """输入编码"""
-    ie: str = "gbk"
+    oe: str = "utf8"
     """输出编码"""
-    oe: str = "gbk"
-    """创建时间 (Unix 时间戳)"""
     createDatetime: int = 0
-    """最后修改时间 (Unix 时间戳)"""
+    """创建时间 (Unix 时间戳)"""
     lastDatetime: int = 0
-    """实例类型 (universal, minecraft 等)"""
+    """最后修改时间 (Unix 时间戳)"""
     type: str = "universal"
+    """实例类型 (universal, minecraft 等)"""
+    tag: list[str] = []
     """实例标签"""
-    tag: List[str] = []
-    """实例结束时间 (可选)"""
-    endTime: Optional[int] = None
+    endTime: int | None = None
+    """实例到期时间"""
+    fileCode: str = "utf8"
     """文件编码"""
-    fileCode: str = "gbk"
-    """进程类型 (如 docker, local)"""
     processType: str = "docker"
-    """更新命令"""
+    """进程类型 (如 docker, local)"""
     updateCommand: str = "shutdown -s"
+    """更新命令"""
+    actionCommandlist: list[str] = []
     """实例可执行的操作命令列表"""
-    actionCommandList: List[str] = []
-    """换行符 (0: LF, 1: CR, 2: CRLF)"""
-    crlf: int = 2
-    """Docker 相关配置"""
+    crlf: CRLFType = CRLFType.CRLF
+    """换行符"""
     docker: "DockerConfig" = DockerConfig()
-    """是否启用 RCON 远程控制"""
+    """Docker 相关配置"""
     enableRcon: bool = True
-    """RCON 连接密码"""
+    """是否启用 RCON 远程控制"""
     rconPassword: str = ""
-    """RCON 端口"""
+    """RCON 连接密码"""
     rconPort: int = 2557
-    """RCON IP 地址"""
+    """RCON 端口"""
     rconIp: str = ""
-    """终端选项配置"""
+    """RCON IP 地址"""
     terminalOption: TerminalOption = TerminalOption()
-    """事件任务配置"""
+    """终端选项配置"""
     eventTask: EventTask = EventTask()
-    """服务器 Ping 监测配置"""
+    """事件任务配置"""
     pingConfig: PingConfig = PingConfig()
+    """服务器 Ping 监测配置"""
+    runAs: str = ""
+    """运行该实例的系统用户，为空则使用启动面板的系统用户"""
 
 
 class ProcessInfo(BaseModel):
     """进程信息"""
 
-    """CPU 使用率 (单位: %)"""
     cpu: int = 0
-    """进程占用内存 (单位: KB)"""
+    """CPU 使用率 (单位: %)"""
     memory: int = 0
-    """父进程 ID"""
+    """进程占用内存 (单位: KB)"""
     ppid: int = 0
-    """进程 ID"""
+    """父进程 ID"""
     pid: int = 0
-    """进程创建时间 (Unix 时间戳)"""
+    """进程 ID"""
     ctime: int = 0
-    """进程运行时长 (单位: 秒)"""
+    """进程创建时间 (Unix 时间戳)"""
     elapsed: int = 0
-    """时间戳"""
+    """进程运行时长 (单位: 秒)"""
     timestamp: int = 0
+    """时间戳"""
 
 
 class InstanceInfo(BaseModel):
-    """实例运行状态信息( 这些选项在新版中已不再支持设置，但仍在API中返回)"""
+    """实例运行状态信息(这些选项在新版中已不再支持设置，但仍在API中返回)"""
 
-    """当前玩家数量 (-1 表示未知)"""
     currentPlayers: int = -1
-    """文件锁状态 (0: 无锁)"""
+    """当前玩家数量 (-1 表示未知)"""
     fileLock: int = 0
-    """最大允许玩家数 (-1 表示未知)"""
+    """文件锁状态 (0: 无锁)"""
     maxPlayers: int = -1
-    """是否启用 FRP 远程服务"""
+    """最大允许玩家数 (-1 表示未知)"""
     openFrpStatus: bool = False
+    """是否启用 FRP 远程服务"""
+    playersChart: list[dict] = []
     """玩家数量变化图表数据"""
-    playersChart: List[Dict] = []
-    """服务器版本"""
     version: str = ""
+    """服务器版本"""
 
 
 class InstanceDetail(BaseModel):
     """实例详细信息"""
 
-    """实例的配置信息"""
     config: InstanceConfig = InstanceConfig()
-    """实例的运行状态信息"""
+    """实例的配置信息"""
     info: InstanceInfo = InstanceInfo()
-    """所属的守护进程 (Daemon) ID"""
+    """实例的运行状态信息"""
     daemonId: str = ""
-    """实例唯一标识符 (UUID)"""
+    """所属的守护进程 (Daemon) ID"""
     instanceUuid: str = ""
-    """实例的进程信息"""
+    """实例唯一标识符 (UUID)"""
     processInfo: ProcessInfo = ProcessInfo()
-    """实例的存储空间大小(始终为`0`)"""
-    space: int = 0  # 在 MCSM 代码中，此项始终为 0，意义不明
-    """实例的启动次数"""
+    """实例的进程信息"""
+    space: int = 0
+    """实例的存储空间大小(已弃用)"""
     started: int = 0
-    """实例状态 (-1: 忙碌, 0: 停止, 1: 停止中, 2: 启动中, 3: 运行中)"""
-    status: int = 0
+    """实例的启动次数"""
+    status: Status = Status.STOP
+    """实例状态"""
 
     def start(self) -> str | bool:
         """
@@ -153,7 +173,7 @@ class InstanceDetail(BaseModel):
         """
         from mcsmapi.apis.instance import Instance
 
-        return Instance().start(self.daemonId, self.instanceUuid)
+        return Instance.start(self.daemonId, self.instanceUuid)
 
     def stop(self) -> str | bool:
         """
@@ -164,7 +184,7 @@ class InstanceDetail(BaseModel):
         """
         from mcsmapi.apis.instance import Instance
 
-        return Instance().stop(self.daemonId, self.instanceUuid)
+        return Instance.stop(self.daemonId, self.instanceUuid)
 
     def restart(self) -> str | bool:
         """
@@ -175,7 +195,7 @@ class InstanceDetail(BaseModel):
         """
         from mcsmapi.apis.instance import Instance
 
-        return Instance().restart(self.daemonId, self.instanceUuid)
+        return Instance.restart(self.daemonId, self.instanceUuid)
 
     def kill(self) -> str | bool:
         """
@@ -186,7 +206,7 @@ class InstanceDetail(BaseModel):
         """
         from mcsmapi.apis.instance import Instance
 
-        return Instance().kill(self.daemonId, self.instanceUuid)
+        return Instance.kill(self.daemonId, self.instanceUuid)
 
     def delete(self, deleteFile=False) -> str:
         """
@@ -197,7 +217,7 @@ class InstanceDetail(BaseModel):
         """
         from mcsmapi.apis.instance import Instance
 
-        return Instance().delete(self.daemonId, [self.instanceUuid], deleteFile)[0]
+        return Instance.delete(self.daemonId, [self.instanceUuid], deleteFile)[0]
 
     def update(self) -> bool:
         """
@@ -208,7 +228,7 @@ class InstanceDetail(BaseModel):
         """
         from mcsmapi.apis.instance import Instance
 
-        return Instance().update(self.daemonId, self.instanceUuid)
+        return Instance.update(self.daemonId, self.instanceUuid)
 
     def updateConfig(self, config: dict) -> str | bool:
         """
@@ -222,14 +242,12 @@ class InstanceDetail(BaseModel):
         """
         from mcsmapi.apis.instance import Instance
 
-        updated_config = self.config.dict()
+        updated_config = self.config.model_dump()
         updated_config.update(config)
 
-        instance_config = InstanceConfig(**updated_config).dict()
+        instance_config = InstanceConfig(**updated_config).model_dump()
 
-        return Instance().updateConfig(
-            self.daemonId, self.instanceUuid, instance_config
-        )
+        return Instance.updateConfig(self.daemonId, self.instanceUuid, instance_config)
 
     def reinstall(self, targetUrl: str, title: str = "", description: str = "") -> bool:
         """
@@ -245,7 +263,7 @@ class InstanceDetail(BaseModel):
         """
         from mcsmapi.apis.instance import Instance
 
-        return Instance().reinstall(
+        return Instance.reinstall(
             self.daemonId, self.instanceUuid, targetUrl, title, description
         )
 
@@ -259,33 +277,33 @@ class InstanceDetail(BaseModel):
         - page_size (int, 可选): 指定每页的文件数量。默认为100。
 
         **返回:**
-        - FileList: 文件列表。
+        - Filelist: 文件列表。
         """
         from mcsmapi.apis.file import File
 
-        return File().show(self.daemonId, self.instanceUuid, target, page, page_size)
+        return File.show(self.daemonId, self.instanceUuid, target, page, page_size)
 
 
 class InstanceCreateResult(BaseModel):
     """实例创建结果"""
 
-    """实例唯一标识符 (UUID)"""
     instanceUuid: str = ""
-    """实例的配置信息"""
+    """实例唯一标识符 (UUID)"""
     config: InstanceConfig = InstanceConfig()
+    """实例的配置信息"""
 
 
 class InstanceSearchList(BaseModel):
     """实例搜索列表"""
 
-    """每页的实例数量"""
     pageSize: int = 0
-    """最大页数"""
+    """每页的实例数量"""
     maxPage: int = 0
+    """最大页数"""
+    data: list[InstanceDetail] = []
     """实例详细信息列表"""
-    data: List[InstanceDetail] = []
-    """所属的守护进程 (Daemon) ID"""
     daemonId: str = ""
+    """所属的守护进程 (Daemon) ID"""
 
     def __init__(self, **data: str):
         """实例化对象，并在每个实例中填充 daemonId"""
@@ -297,7 +315,7 @@ class InstanceSearchList(BaseModel):
 class UserInstancesList(BaseModel):
     """用户实例列表"""
 
-    """实例唯一标识符 (UUID)"""
     instanceUuid: str = ""
-    """所属的守护进程 (Daemon) ID"""
+    """实例唯一标识符 (UUID)"""
     daemonId: str = ""
+    """所属的守护进程 (Daemon) ID"""

--- a/mcsmapi/models/overview.py
+++ b/mcsmapi/models/overview.py
@@ -1,112 +1,102 @@
-from typing import Dict, List, Optional
 from pydantic import BaseModel
+from mcsmapi.models.common import CpuMemChart, InstanceInfo, ProcessInfo
 from mcsmapi.models.daemon import DaemonModel
 
 
 class SystemUser(BaseModel):
     """系统用户信息"""
 
-    """用户 ID (UID)"""
     uid: int = 0
-    """用户组 ID (GID)"""
+    """用户 ID (UID)"""
     gid: int = 0
-    """用户名"""
+    """用户组 ID (GID)"""
     username: str = ""
-    """用户主目录"""
+    """用户名"""
     homedir: str = ""
-    """默认 Shell 解释器 (可选)"""
-    shell: Optional[str] = None
+    """用户主目录"""
+    shell: str | None = None
+    """默认 Shell 解释器"""
 
 
 class SystemInfo(BaseModel):
     """系统信息"""
 
-    """当前登录用户信息"""
     user: SystemUser = SystemUser()
-    """系统当前时间 (Unix 时间戳)"""
+    """当前登录用户信息"""
     time: int = 0
-    """系统总内存大小 (单位: 字节)"""
+    """系统当前时间 (Unix 时间戳)"""
     totalmem: int = 0
-    """系统空闲内存大小 (单位: 字节)"""
+    """系统总内存大小 (单位: 字节)"""
     freemem: int = 0
-    """操作系统类型"""
+    """系统空闲内存大小 (单位: 字节)"""
     type: str = ""
-    """操作系统版本"""
+    """操作系统类型"""
     version: str = ""
-    """系统节点名称"""
+    """操作系统版本"""
     node: str = ""
-    """主机名"""
+    """系统节点名称"""
     hostname: str = ""
+    """主机名"""
+    loadavg: list[float] = []
     """系统负载平均值 (过去 1、5、15 分钟)"""
-    loadavg: List[float] = []
-    """操作系统平台"""
     platform: str = ""
-    """系统发行版本信息"""
+    """操作系统平台"""
     release: str = ""
-    """系统运行时间 (单位: 秒)"""
+    """系统发行版本信息"""
     uptime: float = 0
-    """CPU 当前使用率 (单位: %)"""
+    """系统运行时间 (单位: 秒)"""
     cpu: float = 0
+    """CPU 当前使用率 (单位: %)"""
 
 
 class RecordInfo(BaseModel):
     """安全记录信息"""
 
-    """成功登录次数"""
     logined: int = 0
-    """非法访问次数"""
+    """成功登录次数"""
     illegalAccess: int = 0
-    """被封禁的 IP 数量"""
+    """非法访问次数"""
     banips: int = 0
-    """登录失败次数"""
+    """被封禁的 IP 数量"""
     loginFailed: int = 0
+    """登录失败次数"""
+
 
 
 class ChartInfo(BaseModel):
     """图表数据信息"""
 
-    """系统性能数据 (CPU/内存等)"""
-    system: List[Dict[str, float]] = []
-    """请求统计信息 (HTTP 请求数等)"""
-    request: List[Dict[str, int]] = []
-
-
-class ProcessInfo(BaseModel):
-    """进程信息"""
-
-    """CPU 使用率 (单位: %)"""
-    cpu: int = 0
-    """进程占用内存 (单位: KB)"""
-    memory: int = 0
-    """进程当前工作目录"""
-    cwd: str = ""
+    system: list[CpuMemChart] = []
+    """系统统计信息"""
+    request: list[InstanceInfo] = []
+    """实例统计信息"""
 
 
 class RemoteCountInfo(BaseModel):
     """远程守护进程统计信息"""
 
-    """远程守护进程总数"""
     total: int = 0
-    """可用的远程守护进程数量"""
+    """远程守护进程总数"""
     available: int = 0
+    """可用的远程守护进程数量"""
 
 
 class OverviewModel(BaseModel):
     """系统概览信息"""
 
-    """系统当前版本"""
     version: str = ""
-    """指定的守护进程 (Daemon) 版本"""
+    """系统当前版本"""
     specifiedDaemonVersion: str = ""
-    """系统信息"""
+    """指定的守护进程 (Daemon) 版本"""
     system: SystemInfo = SystemInfo()
-    """安全访问记录"""
+    """系统信息"""
     record: RecordInfo = RecordInfo()
-    """进程状态信息"""
+    """安全访问记录"""
     process: ProcessInfo = ProcessInfo()
-    """系统与请求统计图表数据"""
+    """进程状态信息"""
     chart: ChartInfo = ChartInfo()
-    """远程守护进程统计信息"""
+    """系统与请求统计图表数据"""
     remoteCount: RemoteCountInfo = RemoteCountInfo()
+    """远程守护进程统计信息"""
+    remote: list[DaemonModel] = []
     """远程守护进程详细信息"""
-    remote: List["DaemonModel"] = []

--- a/mcsmapi/models/user.py
+++ b/mcsmapi/models/user.py
@@ -1,37 +1,44 @@
-from typing import Any, List
+from enum import IntEnum
+from typing import Any
 from pydantic import BaseModel
 from mcsmapi.models.instance import InstanceDetail, UserInstancesList
+
+
+class UserPermission(IntEnum):
+    BANNED = -1
+    USER = 1
+    ADMIN = 10
 
 
 class UserModel(BaseModel):
     """用户信息模型"""
 
-    """用户唯一标识符 (UUID)"""
     uuid: str = ""
-    """用户名"""
+    """用户唯一标识符 (UUID)"""
     userName: str = ""
-    """用户密码 (存储加密后的字符串)"""
+    """用户名"""
     passWord: str = ""
-    """密码类型 (0=默认类型)"""
+    """用户密码 (存储加密后的字符串)"""
     passWordType: int = 0
-    """密码盐值 (用于加密)"""
+    """密码类型 (0=默认类型)"""
     salt: str = ""
-    """用户权限级别 (1=用户, 10=管理员, -1=被封禁的用户)"""
-    permission: int = 1
-    """用户注册时间 (时间字符串格式)"""
+    """密码盐值 (用于加密)"""
+    permission: UserPermission = UserPermission.USER
+    """用户权限级别"""
     registerTime: str = ""
-    """用户最后登录时间 (时间字符串格式)"""
+    """用户注册时间 (时间字符串格式)"""
     loginTime: str = ""
-    """用户 API 密钥"""
+    """用户最后登录时间 (时间字符串格式)"""
     apiKey: str = ""
-    """是否为初始化用户 (系统内置用户)"""
+    """用户 API 密钥"""
     isInit: bool = False
-    """用户安全密钥 (可能用于额外的身份验证)"""
+    """是否为初始化用户 (系统内置用户)"""
     secret: str = ""
-    """是否启用双因素认证 (2FA)"""
+    """用户安全密钥 (可能用于额外的身份验证)"""
     open2FA: bool = False
+    """是否启用双因素认证 (2FA)"""
+    instances: list[UserInstancesList] = []
     """用户关联的实例列表"""
-    instances: List["UserInstancesList"] = []
 
     def delete(self) -> bool:
         """
@@ -56,16 +63,16 @@ class UserModel(BaseModel):
         """
         from mcsmapi.apis.user import User
 
-        updated_config = self.dict()
+        updated_config = self.model_dump()
         updated_config.update(config)
         # 过滤用户信息中不需要的字段
         user_config_dict = {
             key: updated_config[key]
-            for key in UserConfig.__fields__.keys()
+            for key in UserConfig.model_fields.keys()
             if key in updated_config
         }
 
-        user_config = UserConfig(**user_config_dict).dict()
+        user_config = UserConfig(**user_config_dict).model_dump()
 
         return User().update(self.uuid, user_config)
 
@@ -73,38 +80,38 @@ class UserModel(BaseModel):
 class SearchUserModel(BaseModel):
     """用户搜索结果"""
 
-    """匹配的用户总数"""
     total: int = 0
-    """当前页码"""
+    """匹配的用户总数"""
     page: int = 0
-    """每页返回的用户数量"""
+    """当前页码"""
     page_size: int = 0
-    """最大可用页数"""
+    """每页返回的用户数量"""
     max_page: int = 0
+    """最大可用页数"""
+    data: list[UserModel] = []
     """用户信息列表"""
-    data: List[UserModel] = []
 
 
 class UserConfig(BaseModel):
     """用户配置信息"""
 
-    """用户唯一标识符 (UUID)"""
     uuid: str
-    """用户名"""
+    """用户唯一标识符 (UUID)"""
     userName: str
-    """最后登录时间"""
+    """用户名"""
     loginTime: str
-    """注册时间"""
+    """最后登录时间"""
     registerTime: str
+    """注册时间"""
+    instances: list[InstanceDetail]
     """用户拥有的实例列表"""
-    instances: List[InstanceDetail]
-    """用户权限级别 (1=用户, 10=管理员, -1=被封禁的用户)"""
-    permission: int
-    """用户 API 密钥"""
+    permission: UserPermission
+    """用户权限级别"""
     apiKey: str
-    """是否为初始化用户 (系统内置用户)"""
+    """用户 API 密钥"""
     isInit: bool
-    """用户安全密钥 (可能用于额外的身份验证)"""
+    """是否为初始化用户 (系统内置用户)"""
     secret: str
-    """是否启用双因素认证 (2FA)"""
+    """用户安全密钥 (可能用于额外的身份验证)"""
     open2FA: bool
+    """是否启用双因素认证 (2FA)"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,12 @@ authors = [
 license = "MIT"
 classifiers = [
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
 ]
+requires-python = ">=3.10"
 urls = {"Source" = "https://github.com/molanp/mcsmapi"}
 
 dependencies = [
   "requests",
-  "pydantic",
+  "pydantic>=2.0.0",
 ]


### PR DESCRIPTION
- 将 API 类中的实例方法改为静态方法，简化使用
- 优化模型定义，提高代码可读性和维护性
- 新增 common 模型模块，用于定义通用的模型结构
- 调整文件列表和 Docker 相关模型结构，增强数据表达能力

## Sourcery 总结

重构 API 类以使用静态方法，并通过整合通用模式、升级到 Pydantic v2 规范、引入枚举类型用于关键字段以及扩展模型结构来现代化所有 Pydantic 模型

新功能：
- 添加一个通用模型模块，包含共享的 CpuMemChart、ProcessInfo 和 InstanceInfo 定义
- 引入多种 IntEnum 类型 (CRLFType, Status, UserPermission, FileType)，以增强模型字段的类型强度

改进：
- 将所有 API 类实例方法转换为静态方法，以简化使用
- 将模型定义升级到 Pydantic v2，使用 model_dump()、现代类型注解和扩展字段，以实现更丰富的数据表示
- 重构并整合模型定义，将共享模式移至 mcsmapi/models/common.py

构建：
- 在 pyproject.toml 中要求 Python >=3.10 和 Pydantic >=2.0

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor API classes to use static methods and modernize all Pydantic models by consolidating common schemas, upgrading to Pydantic v2 conventions, introducing enums for key fields, and expanding model structures

New Features:
- Add a common models module with shared CpuMemChart, ProcessInfo, and InstanceInfo definitions
- Introduce various IntEnum types (CRLFType, Status, UserPermission, FileType) for stronger typing in model fields

Enhancements:
- Convert all API class instance methods to static methods for simplified usage
- Upgrade model definitions to Pydantic v2 with model_dump(), modern type annotations, and extended fields for richer data representation
- Refactor and consolidate model definitions, moving shared schemas into mcsmapi/models/common.py

Build:
- Require Python >=3.10 and Pydantic >=2.0 in pyproject.toml

</details>